### PR TITLE
feat(#10): 마커 리스트 조회 api 구현

### DIFF
--- a/src/main/java/com/example/wespotbackend/marker/Marker.java
+++ b/src/main/java/com/example/wespotbackend/marker/Marker.java
@@ -17,7 +17,7 @@ public class Marker extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @OneToOne
+    @OneToOne(fetch = FetchType.LAZY, optional = false)
     @JoinColumn(name = "feed_id")
     private Feed feed;
 

--- a/src/main/java/com/example/wespotbackend/marker/MarkerService.java
+++ b/src/main/java/com/example/wespotbackend/marker/MarkerService.java
@@ -11,6 +11,9 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 @RequiredArgsConstructor
 @Service
 public class MarkerService {
@@ -42,5 +45,15 @@ public class MarkerService {
         return MarkerResponse.builder()
                 .id(savedMarker.getId())
                 .build();
+    }
+
+    @Transactional(readOnly = true)
+    public List<MarkerResponse> getMarkers(Long userId) {
+        // 사용자가 등록한 마커들 조회
+        List<Marker> markers = markerRepository.findByUserId(userId);
+
+        return markers.stream()
+                .map(MarkerResponse::new)
+                .collect(Collectors.toList());
     }
 }

--- a/src/main/java/com/example/wespotbackend/marker/api/MarkerController.java
+++ b/src/main/java/com/example/wespotbackend/marker/api/MarkerController.java
@@ -5,10 +5,9 @@ import com.example.wespotbackend.marker.MarkerService;
 import com.example.wespotbackend.marker.dto.MarkerRequest;
 import com.example.wespotbackend.marker.dto.MarkerResponse;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 import static com.example.wespotbackend.common.dto.ApiResult.succeed;
 
@@ -28,5 +27,11 @@ public class MarkerController {
     public ApiResult<MarkerResponse> registerMarker(@RequestBody MarkerRequest request) {
         final MarkerResponse savedMarkerResponse = markerService.save(request);
         return succeed(savedMarkerResponse);
+    }
+
+    @GetMapping("/markers/{userId}")
+    public ApiResult<List<MarkerResponse>> getMarkers(@PathVariable Long userId) {
+        final List<MarkerResponse> markerResponses = markerService.getMarkers(userId);
+        return succeed(markerResponses);
     }
 }

--- a/src/main/java/com/example/wespotbackend/marker/dto/MarkerResponse.java
+++ b/src/main/java/com/example/wespotbackend/marker/dto/MarkerResponse.java
@@ -1,5 +1,6 @@
 package com.example.wespotbackend.marker.dto;
 
+import com.example.wespotbackend.marker.Marker;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
@@ -11,8 +12,20 @@ import lombok.ToString;
 public class MarkerResponse {
     private Long id;
 
+    private Double latitude;
+
+    private Double longitude;
+
     @Builder
-    private MarkerResponse(Long id) {
+    private MarkerResponse(Long id, Double latitude, Double longitude) {
         this.id = id;
+        this.latitude = latitude;
+        this.longitude = longitude;
+    }
+
+    public MarkerResponse(Marker marker) {
+        this.id = marker.getId();
+        this.latitude = marker.getMakerLocation().getLatitude();
+        this.longitude = marker.getMakerLocation().getLongitude();
     }
 }


### PR DESCRIPTION
- feed n+1 쿼리 문제로 lazy 로딩 처리
- 마커 응답 dto 속성 추가